### PR TITLE
fix: speaker resets on answer

### DIFF
--- a/common/darwin/Classes/AudioUtils.h
+++ b/common/darwin/Classes/AudioUtils.h
@@ -3,7 +3,7 @@
 #import <WebRTC/WebRTC.h>
 
 @interface AudioUtils : NSObject
-+ (void)ensureAudioSessionWithRecording:(BOOL)recording;
++ (void)ensureAudioSessionWithRecording:(BOOL)recording andSpeaker:(BOOL)speaker;
 // needed for wired headphones to use headphone mic
 + (BOOL)selectAudioInput:(AVAudioSessionPort)type;
 + (void)setSpeakerphoneOn:(BOOL)enable;

--- a/common/darwin/Classes/FlutterWebRTCPlugin.m
+++ b/common/darwin/Classes/FlutterWebRTCPlugin.m
@@ -1445,7 +1445,7 @@ static FlutterWebRTCPlugin *sharedSingleton;
 
 - (void)ensureAudioSession {
 #if TARGET_OS_IPHONE
-  [AudioUtils ensureAudioSessionWithRecording:[self hasLocalAudioTrack]];
+  [AudioUtils ensureAudioSessionWithRecording:[self hasLocalAudioTrack] andSpeaker:_speakerOn];
 #endif
 }
 


### PR DESCRIPTION
Adds ability to ensure that the speaker options remains enabled after audio session changes
Comon cases: 
   - when speaker was enabled durning call initiation, after answering it (shouldn't) resets to default port