### PR TITLE
fix(ios): max fps crash on first init

### DIFF
--- a/common/darwin/Classes/FlutterRTCMediaStream.m
+++ b/common/darwin/Classes/FlutterRTCMediaStream.m
@@ -506,8 +506,14 @@ typedef void (^NavigatorUserMediaSuccessCallback)(RTCMediaStream* mediaStream);
 
     if ([videoDevice lockForConfiguration:NULL]) {
       @try {
-        videoDevice.activeVideoMaxFrameDuration = CMTimeMake(1, (int32_t)selectedFps);
         videoDevice.activeVideoMinFrameDuration = CMTimeMake(1, (int32_t)selectedFps);
+        AVCaptureDeviceFormat *activeFormat = videoDevice.activeFormat;
+        for (AVFrameRateRange *range in activeFormat.videoSupportedFrameRateRanges) {
+          if (range.maxFrameRate >= selectedFps) {
+            videoDevice.activeVideoMaxFrameDuration = CMTimeMake(1, (int32_t)selectedFps);
+            break;
+          }
+        }
       } @catch (NSException* exception) {
         NSLog(@"Failed to set active frame rate!\n User info:%@", exception.userInfo);
       }


### PR DESCRIPTION
This pull request improves the way video frame rates are set for user video streams by ensuring the selected frame rate is supported by the device before applying it. This change helps prevent errors when configuring the camera.

Frame rate configuration update:

* In `FlutterRTCMediaStream.m`, updated the logic in `getUserVideo:` to check if the selected frame rate is within the supported range of the active video format before setting `activeVideoMaxFrameDuration`.