### PR TITLE
fix(android): use CONFIG_RGBA for EGL surface to fix blue tint on Samsung Android 13

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/SurfaceTextureRenderer.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/SurfaceTextureRenderer.java
@@ -41,7 +41,7 @@ public class SurfaceTextureRenderer extends EglRenderer {
 
   public void init(final EglBase.Context sharedContext,
                    RendererCommon.RendererEvents rendererEvents) {
-    init(sharedContext, rendererEvents, EglBase.CONFIG_PLAIN, new GlRectDrawer());
+    init(sharedContext, rendererEvents, EglBase.CONFIG_RGBA, new GlRectDrawer());
   }
 
   /**


### PR DESCRIPTION
## Problem

On Samsung devices with Mali-G52 GPU (e.g. SM-M325FV / Galaxy M32 5G) running Android 13, all rendered video — both the local camera preview and incoming remote video — appears with a blue tint (color filter).

**Root cause:** `SurfaceTextureRenderer.init()` was using `EglBase.CONFIG_PLAIN` which requests `EGL_ALPHA_SIZE=0`. Flutter's `SurfaceProducer` allocates surfaces with `RGBA_8888` format (alpha present). On certain Samsung Android 13 GPU drivers (Mali-G52/MediaTek Helio G85), this mismatch causes the driver to internally store pixels in `BGRA` order instead of `RGBA`, swapping the Red and Blue channels — producing a blue tint on all video surfaces.

Since all `FlutterRTCVideoRenderer` instances share one `EglBase` context (via `EglUtils.getRootEglBase()`), the color corruption affects every renderer simultaneously — both local preview and remote video.

**Why only some devices:** The bug requires a specific combination of GPU driver (Mali-G52/G57), Android 13, and Samsung One UI firmware version. Adreno (Snapdragon) and other Mali generations silently tolerate the `ALPHA_SIZE=0` mismatch and produce correct colors.

**Verified:** The original upstream `flutter-webrtc/flutter-webrtc` repository still has this issue (`CONFIG_PLAIN` unchanged as of the time of this PR).

## Fix

Change the default EGL config in `SurfaceTextureRenderer.init()` from `CONFIG_PLAIN` to `CONFIG_RGBA`:

```java
// Before
init(sharedContext, rendererEvents, EglBase.CONFIG_PLAIN, new GlRectDrawer());

// After
init(sharedContext, rendererEvents, EglBase.CONFIG_RGBA, new GlRectDrawer());
```

`CONFIG_RGBA` sets `EGL_ALPHA_SIZE=8`, matching the `RGBA_8888` format allocated by Flutter's `SurfaceProducer`. The GPU driver no longer reorders color channels.

## Affected devices (confirmed)

- Samsung SM-M325FV (Galaxy M32 5G) — MediaTek Helio G85 / Mali-G52, Android 13

## Test plan

- [ ] Video call on Samsung SM-M325FV (Android 13) — no blue tint on remote video
- [ ] Video call on Samsung SM-M325FV (Android 13) — no blue tint on local camera preview
- [ ] Video call on Snapdragon device — colors unchanged (regression check)
- [ ] Audio-to-video upgrade mid-call — no blue tint after upgrade