### PR TITLE
feat(android): expose preferredOutputOrder in AndroidAudioConfiguration

### DIFF
--- a/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
@@ -326,6 +326,30 @@ public class AudioSwitchManager {
             forceHandleAudioRouting = (Boolean) configuration.get("forceHandleAudioRouting");
         }
         setForceHandleAudioRouting(forceHandleAudioRouting);
+
+        List<String> preferredOutputOrder = null;
+        if (configuration.get("androidPreferredOutputOrder") instanceof List) {
+            //noinspection unchecked
+            preferredOutputOrder = (List<String>) configuration.get("androidPreferredOutputOrder");
+        }
+        setPreferredDeviceOrder(preferredOutputOrder);
+    }
+
+    public void setPreferredDeviceOrder(@Nullable List<String> order) {
+        if (order == null || order.isEmpty()) return;
+        List<Class<? extends AudioDevice>> newList = new ArrayList<>();
+        for (String name : order) {
+            switch (name) {
+                case "bluetooth":    newList.add(AudioDevice.BluetoothHeadset.class); break;
+                case "wiredHeadset": newList.add(AudioDevice.WiredHeadset.class);     break;
+                case "speakerphone": newList.add(AudioDevice.Speakerphone.class);     break;
+                case "earpiece":     newList.add(AudioDevice.Earpiece.class);         break;
+            }
+        }
+        preferredDeviceList = newList;
+        if (audioSwitch != null) {
+            handler.post(() -> Objects.requireNonNull(audioSwitch).setPreferredDeviceList(preferredDeviceList));
+        }
     }
 
     public void setManageAudioFocus(@Nullable Boolean manage) {

--- a/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
+++ b/android/src/main/java/com/cloudwebrtc/webrtc/audio/AudioSwitchManager.java
@@ -7,6 +7,7 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -335,6 +336,12 @@ public class AudioSwitchManager {
         setPreferredDeviceOrder(preferredOutputOrder);
     }
 
+    /**
+     * Sets the AudioSwitch preferred device priority list from a list of device name strings.
+     * <p>
+     * Passing null or an empty list is a no-op — the current order is preserved.
+     * To restore the original default order, pass the full default list explicitly.
+     */
     public void setPreferredDeviceOrder(@Nullable List<String> order) {
         if (order == null || order.isEmpty()) return;
         List<Class<? extends AudioDevice>> newList = new ArrayList<>();
@@ -344,11 +351,12 @@ public class AudioSwitchManager {
                 case "wiredHeadset": newList.add(AudioDevice.WiredHeadset.class);     break;
                 case "speakerphone": newList.add(AudioDevice.Speakerphone.class);     break;
                 case "earpiece":     newList.add(AudioDevice.Earpiece.class);         break;
+                default: Log.w(TAG, "setPreferredDeviceOrder: unknown device name '" + name + "', skipping");
             }
         }
         preferredDeviceList = newList;
         if (audioSwitch != null) {
-            handler.post(() -> Objects.requireNonNull(audioSwitch).setPreferredDeviceList(preferredDeviceList));
+            handler.post(() -> audioSwitch.setPreferredDeviceList(newList));
         }
     }
 

--- a/lib/src/native/android/audio_configuration.dart
+++ b/lib/src/native/android/audio_configuration.dart
@@ -77,6 +77,8 @@ extension AndroidAudioAttributesContentTypeEnumEx on String {
           .firstWhere((d) => d.name == toLowerCase());
 }
 
+enum AndroidAudioOutputDevice { bluetooth, wiredHeadset, earpiece, speakerphone }
+
 class AndroidAudioConfiguration {
   AndroidAudioConfiguration({
     this.manageAudioFocus,
@@ -86,6 +88,7 @@ class AndroidAudioConfiguration {
     this.androidAudioAttributesUsageType,
     this.androidAudioAttributesContentType,
     this.forceHandleAudioRouting,
+    this.preferredOutputOrder,
   });
 
   /// Controls whether audio focus should be automatically managed during
@@ -104,6 +107,22 @@ class AndroidAudioConfiguration {
   /// If this set to true, will attempt to do audio routing regardless of audio mode.
   final bool? forceHandleAudioRouting;
 
+  /// Priority-ordered list of audio output devices for Android AudioSwitch.
+  ///
+  /// AudioSwitch selects the first available device from this list on
+  /// [AudioSwitch.activate]. If null, the existing order is unchanged.
+  ///
+  /// Example for voice calls (earpiece preferred):
+  /// ```dart
+  /// preferredOutputOrder: const [
+  ///   AndroidAudioOutputDevice.bluetooth,
+  ///   AndroidAudioOutputDevice.wiredHeadset,
+  ///   AndroidAudioOutputDevice.earpiece,
+  ///   AndroidAudioOutputDevice.speakerphone,
+  /// ]
+  /// ```
+  final List<AndroidAudioOutputDevice>? preferredOutputOrder;
+
   Map<String, dynamic> toMap() => <String, dynamic>{
         if (manageAudioFocus != null) 'manageAudioFocus': manageAudioFocus!,
         if (androidAudioMode != null)
@@ -120,6 +139,9 @@ class AndroidAudioConfiguration {
               androidAudioAttributesContentType!.name,
         if (forceHandleAudioRouting != null)
           'forceHandleAudioRouting': forceHandleAudioRouting!,
+        if (preferredOutputOrder != null)
+          'androidPreferredOutputOrder':
+              preferredOutputOrder!.map((d) => d.name).toList(),
       };
 
   /// A pre-configured AndroidAudioConfiguration for media playback.


### PR DESCRIPTION
## Summary

- Adds `AndroidAudioOutputDevice` enum (`bluetooth`, `wiredHeadset`, `earpiece`, `speakerphone`) to the Dart API
- Adds `preferredOutputOrder: List<AndroidAudioOutputDevice>?` field to `AndroidAudioConfiguration`
- Java: `setPreferredDeviceOrder(List<String>)` on `AudioSwitchManager` parses device name strings and applies them to `AudioSwitch.setPreferredDeviceList`
- Wired into existing `setAudioConfiguration()` via new `androidPreferredOutputOrder` key

## Motivation

Previously the AudioSwitch `preferredDeviceList` was hardcoded in the plugin constructor (Speakerphone before Earpiece). This caused speaker to activate automatically on every voice call cold-start because `AudioSwitchManager.start()` → `activate()` selects the first available device from the list.

This change lets the app layer control device priority without touching plugin internals. Voice call config (earpiece-first) is now set via `AppAudioManager._configure()` at app init.
