### PR TITLE
fix(web): add conditional exports and web stubs for Android/iOS audio configuration

### DIFF
--- a/lib/flutter_webrtc.dart
+++ b/lib/flutter_webrtc.dart
@@ -19,7 +19,9 @@ export 'src/native/utils.dart'
 export 'src/native/adapter_type.dart';
 export 'src/native/camera_utils.dart';
 export 'src/native/audio_management.dart';
-export 'src/native/android/audio_configuration.dart';
-export 'src/native/ios/audio_configuration.dart';
+export 'src/native/android/audio_configuration.dart'
+    if (dart.library.js_interop) 'src/web/android_audio_configuration.dart';
+export 'src/native/ios/audio_configuration.dart'
+    if (dart.library.js_interop) 'src/web/ios_audio_configuration.dart';
 export 'src/native/rtc_video_platform_view_controller.dart';
 export 'src/native/rtc_video_platform_view.dart';

--- a/lib/src/web/android_audio_configuration.dart
+++ b/lib/src/web/android_audio_configuration.dart
@@ -1,0 +1,146 @@
+enum AndroidAudioMode {
+  normal,
+  callScreening,
+  inCall,
+  inCommunication,
+  ringtone,
+}
+
+extension AndroidAudioModeEnumEx on String {
+  AndroidAudioMode toAndroidAudioMode() =>
+      AndroidAudioMode.values.firstWhere((d) => d.name == toLowerCase());
+}
+
+enum AndroidAudioFocusMode {
+  gain,
+  gainTransient,
+  gainTransientExclusive,
+  gainTransientMayDuck
+}
+
+extension AndroidAudioFocusModeEnumEx on String {
+  AndroidAudioFocusMode toAndroidAudioFocusMode() =>
+      AndroidAudioFocusMode.values.firstWhere((d) => d.name == toLowerCase());
+}
+
+enum AndroidAudioStreamType {
+  accessibility,
+  alarm,
+  dtmf,
+  music,
+  notification,
+  ring,
+  system,
+  voiceCall
+}
+
+extension AndroidAudioStreamTypeEnumEx on String {
+  AndroidAudioStreamType toAndroidAudioStreamType() =>
+      AndroidAudioStreamType.values.firstWhere((d) => d.name == toLowerCase());
+}
+
+enum AndroidAudioAttributesUsageType {
+  alarm,
+  assistanceAccessibility,
+  assistanceNavigationGuidance,
+  assistanceSonification,
+  assistant,
+  game,
+  media,
+  notification,
+  notificationEvent,
+  notificationRingtone,
+  unknown,
+  voiceCommunication,
+  voiceCommunicationSignalling
+}
+
+extension AndroidAudioAttributesUsageTypeEnumEx on String {
+  AndroidAudioAttributesUsageType toAndroidAudioAttributesUsageType() =>
+      AndroidAudioAttributesUsageType.values
+          .firstWhere((d) => d.name == toLowerCase());
+}
+
+enum AndroidAudioAttributesContentType {
+  movie,
+  music,
+  sonification,
+  speech,
+  unknown
+}
+
+extension AndroidAudioAttributesContentTypeEnumEx on String {
+  AndroidAudioAttributesContentType toAndroidAudioAttributesContentType() =>
+      AndroidAudioAttributesContentType.values
+          .firstWhere((d) => d.name == toLowerCase());
+}
+
+enum AndroidAudioOutputDevice { bluetooth, wiredHeadset, earpiece, speakerphone }
+
+class AndroidAudioConfiguration {
+  AndroidAudioConfiguration({
+    this.manageAudioFocus,
+    this.androidAudioMode,
+    this.androidAudioFocusMode,
+    this.androidAudioStreamType,
+    this.androidAudioAttributesUsageType,
+    this.androidAudioAttributesContentType,
+    this.forceHandleAudioRouting,
+    this.preferredOutputOrder,
+  });
+
+  final bool? manageAudioFocus;
+  final AndroidAudioMode? androidAudioMode;
+  final AndroidAudioFocusMode? androidAudioFocusMode;
+  final AndroidAudioStreamType? androidAudioStreamType;
+  final AndroidAudioAttributesUsageType? androidAudioAttributesUsageType;
+  final AndroidAudioAttributesContentType? androidAudioAttributesContentType;
+  final bool? forceHandleAudioRouting;
+  final List<AndroidAudioOutputDevice>? preferredOutputOrder;
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        if (manageAudioFocus != null) 'manageAudioFocus': manageAudioFocus!,
+        if (androidAudioMode != null)
+          'androidAudioMode': androidAudioMode!.name,
+        if (androidAudioFocusMode != null)
+          'androidAudioFocusMode': androidAudioFocusMode!.name,
+        if (androidAudioStreamType != null)
+          'androidAudioStreamType': androidAudioStreamType!.name,
+        if (androidAudioAttributesUsageType != null)
+          'androidAudioAttributesUsageType':
+              androidAudioAttributesUsageType!.name,
+        if (androidAudioAttributesContentType != null)
+          'androidAudioAttributesContentType':
+              androidAudioAttributesContentType!.name,
+        if (forceHandleAudioRouting != null)
+          'forceHandleAudioRouting': forceHandleAudioRouting!,
+        if (preferredOutputOrder != null)
+          'androidPreferredOutputOrder':
+              preferredOutputOrder!.map((d) => d.name).toList(),
+      };
+
+  static final media = AndroidAudioConfiguration(
+    manageAudioFocus: true,
+    androidAudioMode: AndroidAudioMode.normal,
+    androidAudioFocusMode: AndroidAudioFocusMode.gain,
+    androidAudioStreamType: AndroidAudioStreamType.music,
+    androidAudioAttributesUsageType: AndroidAudioAttributesUsageType.media,
+    androidAudioAttributesContentType:
+        AndroidAudioAttributesContentType.unknown,
+  );
+
+  static final communication = AndroidAudioConfiguration(
+    manageAudioFocus: true,
+    androidAudioMode: AndroidAudioMode.inCommunication,
+    androidAudioFocusMode: AndroidAudioFocusMode.gain,
+    androidAudioStreamType: AndroidAudioStreamType.voiceCall,
+    androidAudioAttributesUsageType:
+        AndroidAudioAttributesUsageType.voiceCommunication,
+    androidAudioAttributesContentType: AndroidAudioAttributesContentType.speech,
+  );
+}
+
+class AndroidNativeAudioManagement {
+  static Future<void> setAndroidAudioConfiguration(
+      AndroidAudioConfiguration config) async {}
+}

--- a/lib/src/web/ios_audio_configuration.dart
+++ b/lib/src/web/ios_audio_configuration.dart
@@ -1,0 +1,122 @@
+enum AppleAudioMode {
+  default_,
+  gameChat,
+  measurement,
+  moviePlayback,
+  spokenAudio,
+  videoChat,
+  videoRecording,
+  voiceChat,
+  voicePrompt,
+}
+
+extension AppleAudioModeEnumEx on String {
+  AppleAudioMode toAppleAudioMode() =>
+      AppleAudioMode.values.firstWhere((d) => d.name == toLowerCase());
+}
+
+enum AppleAudioCategory {
+  soloAmbient,
+  playback,
+  record,
+  playAndRecord,
+  multiRoute,
+}
+
+extension AppleAudioCategoryEnumEx on String {
+  AppleAudioCategory toAppleAudioCategory() =>
+      AppleAudioCategory.values.firstWhere((d) => d.name == toLowerCase());
+}
+
+enum AppleAudioCategoryOption {
+  mixWithOthers,
+  duckOthers,
+  interruptSpokenAudioAndMixWithOthers,
+  allowBluetooth,
+  allowBluetoothA2DP,
+  allowAirPlay,
+  defaultToSpeaker,
+}
+
+extension AppleAudioCategoryOptionEnumEx on String {
+  AppleAudioCategoryOption toAppleAudioCategoryOption() =>
+      AppleAudioCategoryOption.values
+          .firstWhere((d) => d.name == toLowerCase());
+}
+
+class AppleAudioConfiguration {
+  AppleAudioConfiguration({
+    this.appleAudioCategory,
+    this.appleAudioCategoryOptions,
+    this.appleAudioMode,
+  });
+  final AppleAudioCategory? appleAudioCategory;
+  final Set<AppleAudioCategoryOption>? appleAudioCategoryOptions;
+  final AppleAudioMode? appleAudioMode;
+
+  Map<String, dynamic> toMap() => <String, dynamic>{
+        if (appleAudioCategory != null)
+          'appleAudioCategory': appleAudioCategory!.name,
+        if (appleAudioCategoryOptions != null)
+          'appleAudioCategoryOptions':
+              appleAudioCategoryOptions!.map((e) => e.name).toList(),
+        if (appleAudioMode != null) 'appleAudioMode': appleAudioMode!.name,
+      };
+}
+
+enum AppleAudioIOMode {
+  none,
+  remoteOnly,
+  localOnly,
+  localAndRemote,
+}
+
+class AppleNativeAudioManagement {
+  static AppleAudioIOMode currentMode = AppleAudioIOMode.none;
+
+  static AppleAudioConfiguration getAppleAudioConfigurationForMode(
+      AppleAudioIOMode mode,
+      {bool preferSpeakerOutput = false}) {
+    currentMode = mode;
+    if (mode == AppleAudioIOMode.remoteOnly) {
+      return AppleAudioConfiguration(
+        appleAudioCategory: AppleAudioCategory.playback,
+        appleAudioCategoryOptions: {
+          AppleAudioCategoryOption.mixWithOthers,
+        },
+        appleAudioMode: AppleAudioMode.spokenAudio,
+      );
+    } else if ([
+      AppleAudioIOMode.localOnly,
+      AppleAudioIOMode.localAndRemote,
+    ].contains(mode)) {
+      return AppleAudioConfiguration(
+        appleAudioCategory: AppleAudioCategory.playAndRecord,
+        appleAudioCategoryOptions: {
+          AppleAudioCategoryOption.allowBluetooth,
+          AppleAudioCategoryOption.mixWithOthers,
+        },
+        appleAudioMode: preferSpeakerOutput
+            ? AppleAudioMode.videoChat
+            : AppleAudioMode.voiceChat,
+      );
+    }
+
+    return AppleAudioConfiguration(
+      appleAudioCategory: AppleAudioCategory.soloAmbient,
+      appleAudioCategoryOptions: {},
+      appleAudioMode: AppleAudioMode.default_,
+    );
+  }
+
+  static Future<void> setAppleAudioConfiguration(
+      AppleAudioConfiguration config) async {}
+
+  static Future<void> setUseManualAudio(bool value) async {}
+
+  static Future<void> setIsAudioEnabled(bool value) async {}
+
+  static Future<void> audioSessionDidActivate() async {}
+
+  static Future<void> audioSessionDidDeactivate() async {}
+}


### PR DESCRIPTION
## Problem

Unconditional exports of `src/native/android/audio_configuration.dart` and `src/native/ios/audio_configuration.dart` in `flutter_webrtc.dart` caused compile errors on web:

```
Error: Undefined name 'AndroidAudioOutputDevice'.
```

**Root cause chain:**
1. `flutter_webrtc.dart` exported both files without a `dart.library.js_interop` guard
2. Both files import `'../utils.dart'` (i.e. `src/native/utils.dart`)
3. `src/native/utils.dart` imports `dart:io` — not available on web
4. Dart web compiler fails to resolve the file → all types defined in it become undefined

Triggered in practice when `webtrit_phone` (a mobile app) is used as a path dependency from a Flutter web project.

## Solution

- Added `lib/src/web/android_audio_configuration.dart` — web stub with identical public API, no-op `AndroidNativeAudioManagement.setAndroidAudioConfiguration()`
- Added `lib/src/web/ios_audio_configuration.dart` — web stub with identical public API, no-op `AppleNativeAudioManagement.*` methods (pure logic in `getAppleAudioConfigurationForMode` is preserved)
- Updated `flutter_webrtc.dart` to use `if (dart.library.js_interop)` conditional exports, matching the existing pattern used for `utils.dart`, `factory_impl.dart`, etc.

## Changes

```
lib/flutter_webrtc.dart                          — conditional exports
lib/src/web/android_audio_configuration.dart     — new web stub
lib/src/web/ios_audio_configuration.dart         — new web stub
```