### PR TITLE
fix(web): add missing restartAudio stub to AppleNativeAudioManagement

### DIFF
--- a/lib/src/web/ios_audio_configuration.dart
+++ b/lib/src/web/ios_audio_configuration.dart
@@ -119,4 +119,6 @@ class AppleNativeAudioManagement {
   static Future<void> audioSessionDidActivate() async {}
 
   static Future<void> audioSessionDidDeactivate() async {}
+
+  static Future<void> restartAudio() async {}
 }


### PR DESCRIPTION
## Summary

- `AppleNativeAudioManagement.restartAudio()` was added to the native iOS stub (`lib/src/native/ios/audio_configuration.dart`) but the web stub (`lib/src/web/ios_audio_configuration.dart`) was not updated
- Web compilation (e.g. Flutter web apps that depend on `flutter_webrtc`) fails with `Member not found: 'AppleNativeAudioManagement.restartAudio'`
- Adds a no-op stub to match the native API surface